### PR TITLE
add parcel-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 haters/
 .cache/
 dist/
+.parcel-cache/


### PR DESCRIPTION
In your videos, Parcel generates a directory named `.cache` but it is now called `.parcel-cache`. Beginners can accidentally commit the Parcel caches so I updated the .gitignore.